### PR TITLE
Fix/2

### DIFF
--- a/src/components/AvatarLink.jsx
+++ b/src/components/AvatarLink.jsx
@@ -1,0 +1,22 @@
+import { useNavigate } from "react-router-dom";
+
+function AvatarLink({ avatar, userId }) {
+  const navigate = useNavigate();
+
+  const handleAvatarClick = (e) => {
+    e.stopPropagation();
+    navigate(`/user/${e.target.dataset.id}`);
+  };
+
+  return (
+    <img
+      src={avatar}
+      alt="avatar"
+      className="hover:drop-shadow-md cursor-pointer"
+      data-id={userId}
+      onClick={handleAvatarClick}
+    />
+  );
+}
+
+export default AvatarLink;

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -22,7 +22,7 @@ const StyledHeader = styled.div`
   }
 
   .title:has(span) {
-    margin-top: -8px;
+    margin-top: -15px;
   }
 
   h1 {
@@ -32,7 +32,6 @@ const StyledHeader = styled.div`
   }
 
   span {
-    margin-top: 5px;
     color: var(--secondary);
     font-size: 13px;
   }

--- a/src/components/LikeIcon.jsx
+++ b/src/components/LikeIcon.jsx
@@ -1,0 +1,87 @@
+import { postTweetLike, postTweetUnLike } from "api/tweetAuth";
+import { useContext } from "react";
+import { TweetContext } from "contexts/TweetContext";
+
+import { ReactComponent as HeartUnfocus } from "assets/icons/heart_unfocus.svg";
+import { ReactComponent as HeartFocus } from "assets/icons/heart_focus.svg";
+
+function LikeIcon({ isLiked, tweetId }) {
+  const {
+    tweets,
+    setTweets,
+    tweet,
+    setTweet,
+    userLikedTweets,
+    setUserLikedTweets,
+  } = useContext(TweetContext);
+
+  // 切換愛心狀態
+  const handleLikeClick = async (e) => {
+    e.stopPropagation();
+
+    try {
+      if (isLiked) {
+        await postTweetUnLike(tweetId);
+
+        // 在 MainPage, UserMainPage 點擊取消喜歡會更動數字與愛心樣式
+        setTweets(
+          tweets.map((tweet) => {
+            if (tweet.id === Number(tweetId)) {
+              return {
+                ...tweet,
+                likeCount: tweet.likeCount - 1,
+                isLiked: !tweet.isLiked,
+              };
+            }
+            return tweet;
+          })
+        );
+
+        // 在 TweetPage 點擊取消喜歡會更動數字與愛心樣式
+        setTweet({
+          ...tweet,
+          likeCount: tweet.likeCount - 1,
+          isLiked: !tweet.isLiked,
+        });
+
+        // 在 UserLikesPage 點擊取消喜歡會直接將該推文從畫面移除
+        setUserLikedTweets(
+          userLikedTweets.filter((tweet) => tweet.TweetId !== Number(tweetId))
+        );
+      } else {
+        await postTweetLike(tweetId);
+
+        // 在 MainPage, UserMainPage 點擊喜歡會更動數字與愛心樣式
+        setTweets(
+          tweets.map((tweet) => {
+            if (tweet.id === Number(tweetId)) {
+              return {
+                ...tweet,
+                likeCount: tweet.likeCount + 1,
+                isLiked: !tweet.isLiked,
+              };
+            }
+            return tweet;
+          })
+        );
+
+        // 在 TweetPage 點擊取消喜歡會更動數字與愛心樣式
+        setTweet({
+          ...tweet,
+          likeCount: tweet.likeCount + 1,
+          isLiked: !tweet.isLiked,
+        });
+      }
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  return isLiked ? (
+    <HeartFocus onClick={handleLikeClick} />
+  ) : (
+    <HeartUnfocus onClick={handleLikeClick} />
+  );
+}
+
+export default LikeIcon;

--- a/src/components/ReplyItem.jsx
+++ b/src/components/ReplyItem.jsx
@@ -1,4 +1,5 @@
 import styled from "styled-components";
+import AvatarLink from "./AvatarLink";
 
 const StyledDiv = styled.div`
   background: var(--white);
@@ -55,8 +56,7 @@ function ReplyItem({
 }) {
   return (
     <StyledDiv className="flex">
-      <img src={avatar} alt="avatar" data-id={userId} />
-
+      <AvatarLink avatar={avatar} userId={userId} />
       <div className="grow">
         <p className="user_info">
           <span className="reply_name">{name}</span>@{account}・{createdAt}

--- a/src/components/SideBar.jsx
+++ b/src/components/SideBar.jsx
@@ -1,12 +1,11 @@
 import styled from "styled-components";
 import { useContext, useEffect } from "react";
-import { useNavigate } from "react-router-dom";
 import { getTopUsers } from "api/tweetAuth";
 import { InfoContext } from "contexts/InfoContext";
 
 // components
-
 import Button from "./Button";
+import AvatarLink from "./AvatarLink";
 
 const StyledDiv = styled.div`
   height: 100vh;
@@ -38,7 +37,6 @@ const StyledPopularItem = styled.div`
     height: 40px;
     border-radius: 50%;
     object-fit: cover;
-    cursor: pointer;
   }
 
   .user-title {
@@ -59,15 +57,9 @@ const StyledPopularItem = styled.div`
 `;
 
 function PopularCard({ id, name, account, avatar, isFollowed, onFollowClick }) {
-  const navigate = useNavigate();
-
-  const handleAvatarClick = (e) => {
-    navigate(`/user/${e.target.dataset.id}`);
-  };
-
   return (
     <StyledPopularItem className="flex">
-      <img src={avatar} data-id={id} alt="avatar" onClick={handleAvatarClick} />
+      <AvatarLink avatar={avatar} userId={id} />
       <div className="user-title flex flex-col">
         <p className="user-name">{name}</p>
         <p>@{account}</p>
@@ -102,7 +94,6 @@ function SideBar() {
     // eslint-disable-next-line
   }, []);
 
-  // !!!
   return (
     <StyledDiv className="col-span-1">
       <StyledPopular>

--- a/src/components/TweetArea.jsx
+++ b/src/components/TweetArea.jsx
@@ -2,6 +2,7 @@ import styled from "styled-components";
 
 // Components
 import Button from "./Button";
+import AvatarLink from "./AvatarLink";
 
 const StyledDiv = styled.div`
   height: 150px;
@@ -24,11 +25,12 @@ const StyledDiv = styled.div`
   }
 `;
 
-function TweetArea({ onTweetClick, avatar }) {
+function TweetArea({ onTweetClick, avatar, userId }) {
+  console.log(userId);
   return (
     <StyledDiv className="flex justify-between" onClick={onTweetClick}>
       <div className="flex grow">
-        <img src={avatar} alt="avatar" />
+        <AvatarLink avatar={avatar} userId={userId} />
         <p className="grow">有什麼新鮮事？</p>
       </div>
       <Button

--- a/src/components/TweetArea.jsx
+++ b/src/components/TweetArea.jsx
@@ -26,7 +26,6 @@ const StyledDiv = styled.div`
 `;
 
 function TweetArea({ onTweetClick, avatar, userId }) {
-  console.log(userId);
   return (
     <StyledDiv className="flex justify-between" onClick={onTweetClick}>
       <div className="flex grow">

--- a/src/components/TweetCard.jsx
+++ b/src/components/TweetCard.jsx
@@ -1,13 +1,11 @@
 import styled from "styled-components";
 import { useNavigate } from "react-router-dom";
-import { useContext, useEffect } from "react";
-import { postTweetLike, postTweetUnLike } from "api/tweetAuth";
+import { useContext } from "react";
 import { TweetContext } from "contexts/TweetContext";
 
 // Components
 import { ReactComponent as ReplyIcon } from "assets/icons/reply_unfocus.svg";
-import { ReactComponent as UnLikeIcon } from "assets/icons/heart_unfocus.svg";
-import { ReactComponent as LikeIcon } from "assets/icons/heart_focus.svg";
+import LikeIcon from "./LikeIcon";
 
 const StyledDiv = styled.div`
   background: var(--white);
@@ -96,42 +94,14 @@ const StyledDiv = styled.div`
   }
 `;
 
-function TweetCard({
-  tweetId,
-  isTweetLike,
-  setIsTweetLike,
-  currentLikeCount,
-  setCurrentLikeCount,
-}) {
+function TweetCard() {
   const navigate = useNavigate();
 
-  const { handleReplyClick, getSingleTweetAsync, tweet } =
-    useContext(TweetContext);
-
-  const handleLikeClick = async (e) => {
-    e.stopPropagation();
-    try {
-      if (isTweetLike) {
-        await postTweetUnLike(tweet.id);
-        setCurrentLikeCount(currentLikeCount - 1);
-      } else {
-        await postTweetLike(tweet.id);
-        setCurrentLikeCount(currentLikeCount + 1);
-      }
-      setIsTweetLike(!isTweetLike);
-    } catch (error) {
-      console.error(error);
-    }
-  };
+  const { handleReplyClick, tweet } = useContext(TweetContext);
 
   const handleAvatarClick = (e) => {
     navigate(`/user/${e.target.dataset.id}`);
   };
-
-  useEffect(() => {
-    getSingleTweetAsync(tweetId);
-    //eslint-disable-next-line
-  }, []);
 
   return (
     <StyledDiv>
@@ -161,17 +131,13 @@ function TweetCard({
             <span>{tweet.replyCount}</span>回覆
           </p>
           <p>
-            <span>{currentLikeCount}</span>喜歡
+            <span>{tweet.likeCount}</span>喜歡
           </p>
         </div>
       </div>
       <div className="card_action flex">
         <ReplyIcon onClick={handleReplyClick} data-id={tweet.id} />
-        {isTweetLike ? (
-          <LikeIcon onClick={handleLikeClick} />
-        ) : (
-          <UnLikeIcon onClick={handleLikeClick} />
-        )}
+        <LikeIcon isLiked={tweet.isLiked} tweetId={tweet.id} />
       </div>
     </StyledDiv>
   );

--- a/src/components/TweetItem.jsx
+++ b/src/components/TweetItem.jsx
@@ -9,6 +9,7 @@ import { ReactComponent as ReplyUnfocus } from "assets/icons/reply_unfocus.svg";
 import { ReactComponent as CrossUnfocus } from "assets/icons/cross_unfocus.svg";
 import { ReactComponent as HeartUnfocus } from "assets/icons/heart_unfocus.svg";
 import { ReactComponent as HeartFocus } from "assets/icons/heart_focus.svg";
+import AvatarLink from "./AvatarLink";
 
 const StyledDiv = styled.div`
   padding: 16px 24px;
@@ -26,10 +27,6 @@ const StyledDiv = styled.div`
     margin-right: 8px;
     border-radius: 50%;
     object-fit: cover;
-
-    &:hover {
-      outline: 2px solid var(--light-orange);
-    }
   }
 
   .grey {
@@ -131,18 +128,13 @@ function UserTweetItem({
     }
   };
 
-  const handleAvatarClick = (e) => {
-    e.stopPropagation();
-    navigate(`/user/${e.target.dataset.id}`);
-  };
-
   return (
     <StyledDiv
       className="flex"
       data-id={tweetId}
       onClick={handleTweetItemClick}
     >
-      <img src={avatar} alt="" data-id={userId} onClick={handleAvatarClick} />
+      <AvatarLink avatar={avatar} userId={userId} />
       <div className="text-box grow">
         <div>
           <span className="user-name">{name}</span>

--- a/src/components/TweetItem.jsx
+++ b/src/components/TweetItem.jsx
@@ -1,15 +1,13 @@
 import styled from "styled-components";
 import { useNavigate } from "react-router-dom";
-import { useContext, useState } from "react";
-import { postTweetLike, postTweetUnLike } from "api/tweetAuth";
+import { useContext } from "react";
 import { TweetContext } from "contexts/TweetContext";
 
 // Components
 import { ReactComponent as ReplyUnfocus } from "assets/icons/reply_unfocus.svg";
 import { ReactComponent as CrossUnfocus } from "assets/icons/cross_unfocus.svg";
-import { ReactComponent as HeartUnfocus } from "assets/icons/heart_unfocus.svg";
-import { ReactComponent as HeartFocus } from "assets/icons/heart_focus.svg";
 import AvatarLink from "./AvatarLink";
+import LikeIcon from "./LikeIcon";
 
 const StyledDiv = styled.div`
   padding: 16px 24px;
@@ -101,32 +99,12 @@ function UserTweetItem({
   replyCount,
   likeCount,
   isLiked,
-  tweet,
 }) {
   const { handleReplyClick } = useContext(TweetContext);
   const navigate = useNavigate();
-  const [isTweetLike, setIsTweetLike] = useState(isLiked);
-  const [currentLikeCount, setCurrentLikeCount] = useState(likeCount);
 
   const handleTweetItemClick = () => {
     navigate(`/tweet/${tweetId}`);
-  };
-
-  // 切換愛心狀態
-  const handleLikeClick = async (e) => {
-    e.stopPropagation();
-    try {
-      if (isTweetLike) {
-        await postTweetUnLike(tweetId);
-        setCurrentLikeCount(currentLikeCount - 1);
-      } else {
-        await postTweetLike(tweetId);
-        setCurrentLikeCount(currentLikeCount + 1);
-      }
-      setIsTweetLike(!isTweetLike);
-    } catch (error) {
-      console.error(error);
-    }
   };
 
   return (
@@ -150,9 +128,9 @@ function UserTweetItem({
             <ReplyUnfocus onClick={handleReplyClick} data-id={tweetId} />
             <span>{replyCount}</span>
           </div>
-          <div className="flex items-center" onClick={handleLikeClick}>
-            {isTweetLike ? <HeartFocus /> : <HeartUnfocus />}
-            <span>{currentLikeCount}</span>
+          <div className="flex items-center">
+            <LikeIcon isLiked={isLiked} tweetId={tweetId} />
+            <span>{likeCount}</span>
           </div>
         </div>
       </div>

--- a/src/components/TweetItem.jsx
+++ b/src/components/TweetItem.jsx
@@ -30,6 +30,7 @@ const StyledDiv = styled.div`
   }
 
   .grey {
+    font-size: 14px;
     color: var(--secondary);
   }
 
@@ -39,13 +40,13 @@ const StyledDiv = styled.div`
 
     .user-name {
       font-weight: bold;
-      font-size: 20px;
+      font-size: 16px;
       margin-right: 5px;
     }
 
     .description {
       overflow-wrap: anywhere;
-      padding-top: 15px;
+      padding-top: 8px;
       line-height: 1.6;
     }
   }

--- a/src/components/UserCards.jsx
+++ b/src/components/UserCards.jsx
@@ -7,7 +7,7 @@ import Header from "components/Header";
 
 const StyledCardCollection = styled.div`
   width: 100%;
-  height: calc(100vh - 75px);
+  max-height: calc(100vh - 75px);
   padding: 16px;
   overflow: scroll;
 `;

--- a/src/components/UserItem.jsx
+++ b/src/components/UserItem.jsx
@@ -4,16 +4,11 @@ import { InfoContext } from "contexts/InfoContext";
 
 // Components
 import Button from "./Button";
+import AvatarLink from "./AvatarLink";
 
 const StyledDiv = styled.div`
   padding: 16px 24px;
   border-bottom: 1px solid #e6ecf0;
-  img,
-  span,
-  p,
-  svg {
-    cursor: pointer;
-  }
 
   .grey {
     color: var(--secondary);
@@ -58,7 +53,7 @@ function UserItem({
 
   return (
     <StyledDiv className="flex">
-      <img src={avatar} alt="" />
+      <AvatarLink avatar={avatar} userId={id} />
       <div className="text-box flex flex-col flex-wrap">
         <div className="flex justify-between items-center">
           <div>

--- a/src/contexts/TweetContext.jsx
+++ b/src/contexts/TweetContext.jsx
@@ -7,6 +7,7 @@ export function TweetContextProvider({ children }) {
   const [tweet, setTweet] = useState({});
   const [tweetReplies, setTweetReplies] = useState([]);
   const [tweets, setTweets] = useState([]);
+  const [userLikedTweets, setUserLikedTweets] = useState([]);
   const [isTweetModalShow, setIsTweetModalShow] = useState(false);
   const [isReplyModalShow, setIsReplyModalShow] = useState(false);
   const [tweetId, setTweetId] = useState(0);
@@ -37,16 +38,18 @@ export function TweetContextProvider({ children }) {
       value={{
         isTweetModalShow,
         handleTweetClick,
-        tweets,
-        setTweets,
         isReplyModalShow,
         handleReplyClick,
+        tweets,
+        setTweets,
+        tweetId,
         getSingleTweetAsync,
         tweet,
         setTweet,
-        tweetId,
         tweetReplies,
         setTweetReplies,
+        userLikedTweets,
+        setUserLikedTweets,
       }}
     >
       {children}

--- a/src/pages/AdminLoginPage.jsx
+++ b/src/pages/AdminLoginPage.jsx
@@ -127,7 +127,12 @@ function AdminLoginPage() {
         </Button>
       </form>
       <div className="flex justify-end mt-4 p-2">
-        <Link to="/login">前台登入</Link>
+        <Link
+          to="/login"
+          className="text-blue-500 underline underline-offset-4 hover:text-blue-700"
+        >
+          前台登入
+        </Link>
       </div>
     </AuthContainer>
   );

--- a/src/pages/FollowersPage.jsx
+++ b/src/pages/FollowersPage.jsx
@@ -5,6 +5,7 @@ import { TweetContext } from "contexts/TweetContext";
 import { InfoContext } from "contexts/InfoContext";
 
 // Components
+import PageContainer from "components/containers/PageContainer";
 import MainContainer from "components/containers/MainContainer";
 import ModalContainer from "components/containers/ModalContainer";
 import Header from "components/Header";
@@ -12,7 +13,6 @@ import NavBar from "components/NavBar";
 import SideBar from "components/SideBar";
 import SwitchBar from "components/SwitchBar";
 import UserItem from "components/UserItem";
-import PageContainer from "components/containers/PageContainer";
 
 function FollowersPage() {
   const [currentPage, setCurrentPage] = useState("followers");

--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -130,9 +130,19 @@ function LoginPage() {
         </Button>
       </form>
       <div className="flex justify-end mt-4 p-2">
-        <Link to="/register">註冊</Link>
+        <Link
+          to="/register"
+          className="text-blue-500 underline underline-offset-4 hover:text-blue-700"
+        >
+          註冊
+        </Link>
         <span className="mx-2">・</span>
-        <Link to="/admin">後台登入</Link>
+        <Link
+          to="/admin"
+          className="text-blue-500 underline underline-offset-4 hover:text-blue-700"
+        >
+          後台登入
+        </Link>
       </div>
     </AuthContainer>
   );

--- a/src/pages/MainPage.jsx
+++ b/src/pages/MainPage.jsx
@@ -60,6 +60,7 @@ function MainPage() {
         <TweetArea
           onTweetClick={handleTweetClick}
           avatar={loginUserInfo.avatar}
+          userId={loginUserInfo.id}
         />
         <div>
           {tweets.map((tweet) => (

--- a/src/pages/MainPage.jsx
+++ b/src/pages/MainPage.jsx
@@ -5,14 +5,14 @@ import { TweetContext } from "contexts/TweetContext";
 import { InfoContext } from "contexts/InfoContext";
 
 // Components
+import PageContainer from "components/containers/PageContainer";
 import MainContainer from "components/containers/MainContainer";
+import ModalContainer from "components/containers/ModalContainer";
 import SideBar from "components/SideBar";
 import TweetArea from "components/TweetArea";
 import Header from "components/Header";
 import NavBar from "components/NavBar";
 import { UserTweetItem } from "components/TweetItem";
-import ModalContainer from "components/containers/ModalContainer";
-import PageContainer from "components/containers/PageContainer";
 
 function MainPage() {
   const {

--- a/src/pages/RegisterPage.jsx
+++ b/src/pages/RegisterPage.jsx
@@ -260,7 +260,12 @@ function RegisterPage() {
         </Button>
       </form>
       <div className="flex justify-center mt-6">
-        <Link to="/login">取消</Link>
+        <Link
+          to="/login"
+          className="text-blue-500 underline underline-offset-4 hover:text-blue-700"
+        >
+          取消
+        </Link>
       </div>
     </AuthContainer>
   );

--- a/src/pages/TweetPage.jsx
+++ b/src/pages/TweetPage.jsx
@@ -1,6 +1,6 @@
-import { useContext, useEffect, useState } from "react";
+import { useContext, useEffect } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
-import { getSingleTweet, getSingleTweetReplies } from "api/tweetAuth";
+import { getSingleTweetReplies } from "api/tweetAuth";
 import { TweetContext } from "contexts/TweetContext";
 import { InfoContext } from "contexts/InfoContext";
 
@@ -15,16 +15,13 @@ import TweetCard from "components/TweetCard";
 import PageContainer from "components/containers/PageContainer";
 
 function TweetPage() {
-  const [tweet, setTweet] = useState({});
-  const [isTweetLike, setIsTweetLike] = useState(0);
-  const [currentLikeCount, setCurrentLikeCount] = useState(0);
-
   const {
     isTweetModalShow,
     handleTweetClick,
     isReplyModalShow,
     tweetReplies,
     setTweetReplies,
+    getSingleTweetAsync,
   } = useContext(TweetContext);
   const { isUserLogin, loginAlert } = useContext(InfoContext);
 
@@ -43,17 +40,6 @@ function TweetPage() {
 
   // 取得單一推文資訊
   useEffect(() => {
-    const getSingleTweetAsync = async () => {
-      try {
-        const singleTweet = await getSingleTweet(tweetId);
-        setTweet(singleTweet);
-        setIsTweetLike(singleTweet.isLiked);
-        setCurrentLikeCount(singleTweet.likeCount);
-      } catch (error) {
-        console.error(error);
-      }
-    };
-
     const getSingleTweetRepliesAsync = async () => {
       try {
         const singleTweetReplies = await getSingleTweetReplies(tweetId);
@@ -63,7 +49,7 @@ function TweetPage() {
       }
     };
 
-    getSingleTweetAsync();
+    getSingleTweetAsync(tweetId);
     getSingleTweetRepliesAsync();
     //eslint-disable-next-line
   }, [tweetId]);
@@ -77,14 +63,7 @@ function TweetPage() {
         <Header backIcon="true">
           <h1>推文</h1>
         </Header>
-        <TweetCard
-          tweet={tweet}
-          tweetId={tweetId}
-          isTweetLike={isTweetLike}
-          setIsTweetLike={setIsTweetLike}
-          currentLikeCount={currentLikeCount}
-          setCurrentLikeCount={setCurrentLikeCount}
-        />
+        <TweetCard />
         {tweetReplies.map((reply) => (
           <ReplyItem
             key={reply.id}

--- a/src/pages/UserLikesPage.jsx
+++ b/src/pages/UserLikesPage.jsx
@@ -21,7 +21,8 @@ function UserLikesPage() {
 
   const { isTweetModalShow, handleTweetClick, isReplyModalShow } =
     useContext(TweetContext);
-  const { isUserLogin, loginAlert, pageUserInfo } = useContext(InfoContext);
+  const { isUserLogin, loginAlert, pageUserInfo, loginUserInfo } =
+    useContext(InfoContext);
 
   const navigate = useNavigate();
   const location = useLocation();
@@ -60,7 +61,7 @@ function UserLikesPage() {
     };
 
     getUserLikedTweetsAsync();
-  }, [pageUserId]);
+  }, [pageUserId, loginUserInfo]);
 
   return (
     <PageContainer>

--- a/src/pages/UserLikesPage.jsx
+++ b/src/pages/UserLikesPage.jsx
@@ -16,11 +16,15 @@ import { UserTweetItem } from "components/TweetItem";
 import PageContainer from "components/containers/PageContainer";
 
 function UserLikesPage() {
-  const [userLikedTweets, setUserLikedTweets] = useState([]);
   const [currentPage, setCurrentPage] = useState("likes");
 
-  const { isTweetModalShow, handleTweetClick, isReplyModalShow } =
-    useContext(TweetContext);
+  const {
+    isTweetModalShow,
+    handleTweetClick,
+    isReplyModalShow,
+    userLikedTweets,
+    setUserLikedTweets,
+  } = useContext(TweetContext);
   const { isUserLogin, loginAlert, pageUserInfo, loginUserInfo } =
     useContext(InfoContext);
 
@@ -61,7 +65,7 @@ function UserLikesPage() {
     };
 
     getUserLikedTweetsAsync();
-  }, [pageUserId, loginUserInfo]);
+  }, [pageUserId, loginUserInfo, setUserLikedTweets]);
 
   return (
     <PageContainer>

--- a/src/pages/UserMainPage.jsx
+++ b/src/pages/UserMainPage.jsx
@@ -5,6 +5,7 @@ import { TweetContext } from "contexts/TweetContext";
 import { InfoContext } from "contexts/InfoContext";
 
 // Components
+import PageContainer from "components/containers/PageContainer";
 import MainContainer from "components/containers/MainContainer";
 import ModalContainer from "components/containers/ModalContainer";
 import Header from "components/Header";
@@ -13,7 +14,6 @@ import SideBar from "components/SideBar";
 import SwitchBar from "components/SwitchBar";
 import UserInfo from "components/UserInfo";
 import { UserTweetItem } from "components/TweetItem";
-import PageContainer from "components/containers/PageContainer";
 
 function UserMainPage() {
   const [currentPage, setCurrentPage] = useState("tweets");

--- a/src/pages/UserMainPage.jsx
+++ b/src/pages/UserMainPage.jsx
@@ -25,7 +25,8 @@ function UserMainPage() {
     handleTweetClick,
     isReplyModalShow,
   } = useContext(TweetContext);
-  const { isUserLogin, loginAlert, pageUserInfo } = useContext(InfoContext);
+  const { isUserLogin, loginAlert, pageUserInfo, loginUserInfo } =
+    useContext(InfoContext);
 
   const navigate = useNavigate();
   const location = useLocation();
@@ -60,7 +61,7 @@ function UserMainPage() {
     };
 
     getUserTweetsAsync();
-  }, [pageUserId, setTweets]);
+  }, [pageUserId, setTweets, loginUserInfo]);
 
   return (
     <PageContainer>

--- a/src/pages/UserReplysPage.jsx
+++ b/src/pages/UserReplysPage.jsx
@@ -20,7 +20,8 @@ function UserReplysPage() {
   const [currentPage, setCurrentPage] = useState("replys");
 
   const { isTweetModalShow, handleTweetClick } = useContext(TweetContext);
-  const { isUserLogin, loginAlert, pageUserInfo } = useContext(InfoContext);
+  const { isUserLogin, loginAlert, pageUserInfo, loginUserInfo } =
+    useContext(InfoContext);
 
   const navigate = useNavigate();
   const location = useLocation();
@@ -59,7 +60,7 @@ function UserReplysPage() {
     };
 
     getUserRepliesAsync();
-  }, [pageUserId]);
+  }, [pageUserId, loginUserInfo]);
 
   return (
     <PageContainer>


### PR DESCRIPTION
樣式修正：
1. 使用 Tailwind 後 `<Link>` 樣式被變動，修正為原樣，並增加 hover 效果
2. 後台使用者列表的 height 隨內容物更動，但不超過畫面（避免長螢幕導致奇怪的間距）
3. 微調 Header、TweetItem 的樣式，使畫面更一致

功能修正：
1. 點選任何頭貼都能到該頭貼使用者的頁面（之前有幾處無法作用），製作 `<AvatarLink>` 元件來複用邏輯
2. 將 Like/unLike 的邏輯包在 `<LikeIcon>` 中複用，在任何地方點選都能讓畫面與後台有相應的反應