### PR TITLE
Fix/3

### DIFF
--- a/src/api/followerAuth.js
+++ b/src/api/followerAuth.js
@@ -38,9 +38,7 @@ export const postFollowships = async ({ id }) => {
 
 export const deleteFollowships = async ({ id }) => {
   try {
-    const res = await axiosInstance.delete(`${baseUrl}/${id}`, {
-      id,
-    });
+    const res = await axiosInstance.delete(`${baseUrl}/${id}`);
 
     return res.data;
   } catch (error) {

--- a/src/components/SideBar.jsx
+++ b/src/components/SideBar.jsx
@@ -91,8 +91,7 @@ function SideBar() {
       }
     };
     getTopUsersAsync();
-    // eslint-disable-next-line
-  }, []);
+  }, [setTopUsers]);
 
   return (
     <StyledDiv className="col-span-1">

--- a/src/components/SwitchBar.jsx
+++ b/src/components/SwitchBar.jsx
@@ -59,13 +59,13 @@ function FollowPageSwitchBar({ onPageChange, currentPage }) {
         className={currentPage === "followers" ? "active" : ""}
         onClick={() => onPageChange?.("followers")}
       >
-        <h1>追隨者</h1>
+        <h1>跟隨者</h1>
       </div>
       <div
         className={currentPage === "following" ? "active" : ""}
         onClick={() => onPageChange?.("following")}
       >
-        <h1>正在追隨</h1>
+        <h1>正在跟隨</h1>
       </div>
     </StyledDiv>
   );

--- a/src/components/UserInfo.jsx
+++ b/src/components/UserInfo.jsx
@@ -165,13 +165,13 @@ function UserInfo({ pageUserId }) {
         <span className="grey">@{pageUserInfo.account}</span>
         <p>{pageUserInfo.introduction}</p>
         <div className="follow-box flex">
+          <p onClick={() => navigate(`/user/${pageUserId}/followers`)}>
+            <span>{pageUserInfo.followerCount} 個</span>
+            <span className="grey">跟隨者</span>
+          </p>
           <p onClick={() => navigate(`/user/${pageUserId}/following`)}>
             <span>{pageUserInfo.followingCount} 個</span>
-            <span className="grey">跟隨中</span>
-          </p>
-          <p onClick={() => navigate(`/user/${pageUserId}/followers`)}>
-            <span>{pageUserInfo.followerCount} 位</span>
-            <span className="grey">跟隨者</span>
+            <span className="grey">正在跟隨</span>
           </p>
         </div>
       </div>

--- a/src/components/modals/ReplyModal.jsx
+++ b/src/components/modals/ReplyModal.jsx
@@ -198,8 +198,7 @@ function ReplyModal() {
 
   useEffect(() => {
     getSingleTweetAsync(tweetId);
-    //eslint-disable-next-line
-  }, []);
+  }, [getSingleTweetAsync, tweetId]);
 
   return (
     <StyledDiv>

--- a/src/contexts/InfoContext.jsx
+++ b/src/contexts/InfoContext.jsx
@@ -144,8 +144,10 @@ export function InfoContextProvider({ children }) {
   // useEffect
   // 打當前頁面的使用者資料
   useEffect(() => {
+    console.log("info out");
     // 有進入 UserPages 系列，並且抓到 id 才打資料
     if (isUserPages && pageUserId) {
+      console.log("info in");
       const getUserInfoAsync = async () => {
         try {
           const userInfoData = await getUserInfo(pageUserId);
@@ -166,6 +168,7 @@ export function InfoContextProvider({ children }) {
             });
 
             navigate("/main");
+
             return;
           }
 
@@ -177,8 +180,7 @@ export function InfoContextProvider({ children }) {
 
       getUserInfoAsync();
     }
-    //eslint-disable-next-line
-  }, [isUserPages, pageUserId]);
+  }, [isUserPages, navigate, pageUserId]);
 
   // 打登入者的資料
   useEffect(() => {

--- a/src/contexts/InfoContext.jsx
+++ b/src/contexts/InfoContext.jsx
@@ -52,7 +52,9 @@ export function InfoContextProvider({ children }) {
         followingInfo = await postFollowships({ id });
       }
 
+      // 更新 User 頁面的數字
       setPageUserInfo((pageUserInfo) => {
+        // 如果是在點擊跟隨/取消跟隨的那個 User 頁面，要更改的是 follower 數量
         if (pageUserInfo.id === id) {
           return {
             ...pageUserInfo,
@@ -62,7 +64,9 @@ export function InfoContextProvider({ children }) {
             isFollowed: !pageUserInfo.isFollowed,
           };
         }
-        if (pageUserInfo.id !== id) {
+
+        // 如果是在自己的 User 頁面，要更改的是 following 數量
+        if (pageUserInfo.id === loginUserId) {
           return {
             ...pageUserInfo,
             followingCount: isFollowed
@@ -71,8 +75,12 @@ export function InfoContextProvider({ children }) {
             isFollowed: !pageUserInfo.isFollowed,
           };
         }
+
+        // 其餘的狀況都不用變
+        return { ...pageUserInfo };
       });
 
+      // 更新右邊推薦跟隨的按鈕狀態
       setTopUsers((topUsers) => {
         return topUsers.map((topUser) => {
           if (topUser.id === id) {
@@ -85,6 +93,7 @@ export function InfoContextProvider({ children }) {
         });
       });
 
+      // 在跟隨中的頁面
       setFollowings((followings) => {
         // 在自己的頁面取消追蹤會過濾掉，增加追蹤會即時顯示
         if (pageUserId === loginUserId) {
@@ -96,6 +105,7 @@ export function InfoContextProvider({ children }) {
             return [followingInfo, ...followings];
           }
         }
+
         // 在別人的頁面去消追蹤只會更改跟隨按鈕的樣式
         return followings.map((following) => {
           if (following.followingId === id) {
@@ -111,6 +121,7 @@ export function InfoContextProvider({ children }) {
         });
       });
 
+      // 在跟隨者頁面畫面只會更改按鈕狀態
       setFollowers((followers) => {
         return followers.map((follower) => {
           if (follower.followerId === id) {

--- a/src/contexts/TweetContext.jsx
+++ b/src/contexts/TweetContext.jsx
@@ -1,5 +1,5 @@
 import { getSingleTweet } from "api/tweetAuth";
-import { createContext, useState } from "react";
+import { createContext, useCallback, useState } from "react";
 
 export const TweetContext = createContext("");
 
@@ -24,14 +24,14 @@ export function TweetContextProvider({ children }) {
     setIsReplyModalShow(!isReplyModalShow);
   };
 
-  const getSingleTweetAsync = async (tweetId) => {
+  const getSingleTweetAsync = useCallback(async (tweetId) => {
     try {
       const singleTweet = await getSingleTweet(tweetId);
       setTweet(singleTweet);
     } catch (error) {
       console.error(error);
     }
-  };
+  }, []);
 
   return (
     <TweetContext.Provider

--- a/src/pages/FollowersPage.jsx
+++ b/src/pages/FollowersPage.jsx
@@ -17,8 +17,7 @@ import UserItem from "components/UserItem";
 function FollowersPage() {
   const [currentPage, setCurrentPage] = useState("followers");
 
-  const { tweets, isTweetModalShow, handleTweetClick } =
-    useContext(TweetContext);
+  const { isTweetModalShow, handleTweetClick } = useContext(TweetContext);
   const {
     isUserLogin,
     loginAlert,
@@ -66,11 +65,11 @@ function FollowersPage() {
   return (
     <PageContainer>
       {isTweetModalShow && <ModalContainer value="推文" />}
-      <NavBar isUser={true} onTweetClick={handleTweetClick} />
+      <NavBar isUser={true} onTweetClick={handleTweetClick} status="個人資料" />
       <MainContainer>
         <Header backIcon={true}>
           <h1>{pageUserInfo.name}</h1>
-          <span>{tweets.length} 則推文</span>
+          <span>{followers.length} 個跟隨者</span>
         </Header>
         <SwitchBar
           value="follow"

--- a/src/pages/FollowersPage.jsx
+++ b/src/pages/FollowersPage.jsx
@@ -59,8 +59,7 @@ function FollowersPage() {
       }
     };
     getFollowersAsync();
-    // eslint-disable-next-line
-  }, [pageUserId]);
+  }, [pageUserId, setFollowers]);
 
   return (
     <PageContainer>

--- a/src/pages/FollowingPage.jsx
+++ b/src/pages/FollowingPage.jsx
@@ -59,8 +59,7 @@ function FollowingPage() {
       }
     };
     getFollowingsAsync();
-    // eslint-disable-next-line
-  }, [pageUserId]);
+  }, [pageUserId, setFollowings]);
 
   return (
     <PageContainer>

--- a/src/pages/FollowingPage.jsx
+++ b/src/pages/FollowingPage.jsx
@@ -17,8 +17,7 @@ import PageContainer from "components/containers/PageContainer";
 function FollowingPage() {
   const [currentPage, setCurrentPage] = useState("following");
 
-  const { tweets, isTweetModalShow, handleTweetClick } =
-    useContext(TweetContext);
+  const { isTweetModalShow, handleTweetClick } = useContext(TweetContext);
   const {
     isUserLogin,
     loginAlert,
@@ -66,11 +65,11 @@ function FollowingPage() {
   return (
     <PageContainer>
       {isTweetModalShow && <ModalContainer value="推文" />}
-      <NavBar isUser={true} onTweetClick={handleTweetClick} />
+      <NavBar isUser={true} onTweetClick={handleTweetClick} status="個人資料" />
       <MainContainer>
         <Header backIcon={true}>
           <h1>{pageUserInfo.name}</h1>
-          <span>{tweets.length} 則推文</span>
+          <span>{followings.length} 個正在跟隨</span>
         </Header>
         <SwitchBar
           value="follow"

--- a/src/pages/TweetPage.jsx
+++ b/src/pages/TweetPage.jsx
@@ -51,8 +51,7 @@ function TweetPage() {
 
     getSingleTweetAsync(tweetId);
     getSingleTweetRepliesAsync();
-    //eslint-disable-next-line
-  }, [tweetId]);
+  }, [getSingleTweetAsync, setTweetReplies, tweetId]);
 
   return (
     <PageContainer>


### PR DESCRIPTION
優化使用者體驗：
1. 統一頁面中的「跟隨中 / 正在跟隨」字樣，且微調 User 頁面擺放順序，避免在使用 switch bar 時錯亂
2. 在「跟隨中 / 正在跟隨」頁面 Header 會顯示總「跟隨中 / 正在跟隨」數量
3. 屬於 User 頁面的，NavBar 的個人資料都會亮起

功能修復：
1. 在 使用者A 頁面點擊跟隨或取消跟隨 使用者B 不會影響到 使用者A 的「跟隨中數量」
2. 修正 useEffect 所需要依賴的 dependencies ，取消高度非必要性的使用「eslint-disable-next-line」，增加使用 useCallBack 來避免無限迴圈